### PR TITLE
Added a tutorial on how to run "two-mappers" example

### DIFF
--- a/examples/pipelines/two-mappers/README.md
+++ b/examples/pipelines/two-mappers/README.md
@@ -126,7 +126,7 @@ downloading, and in the case of samples being extracted from `.sra` file, the
 
 Now, in fact **fork** isn't really necessary in the above example, however, 
 the idea is for you to continue on your own after this example. For instance 
-you may try to run `samtools faidx`  after the fork, which will render two 
+you may try to run `samtools`  after the fork, which will render two 
 independent results, one for `bowtie` results and another for `bwa` results. 
 The pipeline would look something like this:
 
@@ -142,7 +142,7 @@ const pipeline = join(
     join(IndexReferenceBwa, bwaMapper),
     join(indexReferenceBowtie2, bowtieMapper)
   ),
-  samtoolsFaidx
+  samtoolsStuff
 )
 ```
 

--- a/examples/pipelines/two-mappers/README.md
+++ b/examples/pipelines/two-mappers/README.md
@@ -1,0 +1,168 @@
+# bionode-watermill - mappers example pipeline
+
+This example assumes that either you have completed the 
+[bionode-watermill tutorial](https://github.com/bionode/bionode-watermill-tutorial)
+or that you are already comfortable enough to produce your own pipelines 
+using bionode-watermill.
+
+## Requirements for this example
+
+First of all, you will need to clone bionode-watermill if you haven't done it
+ yet: `git clone https://github.com/bionode/bionode-watermill`
+
+Also, you need to have installed:
+
+1) **[bionode-ncbi](https://github.com/bionode/bionode-ncbi)** (however, this 
+one is not really necessary assuming that you 
+run the examples from within the bionode-watermill folders).
+2) **[sra-toolkit](https://www.ncbi.nlm.nih.gov/books/NBK158900/)**
+3) **[bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml)**
+4) **[bwa](http://bio-bwa.sourceforge.net/)**
+5) **[samtools](http://samtools.sourceforge.net/)**
+
+However, don't worry you can use this docker image instead. (**under 
+construction**).
+
+## What for?
+
+This example pipeline intends to download a reference genome of 
+_Streptococcus pneumoniae_ and the SRA accession 'ERR045788', and then map the
+ reads available in this accession against the reference genome.
+ Then, some other processes are suggested but you can configure this pipeline
+  according to your own needs (which might be a good starting point to 
+  understand the mechanics of bionode-watermill).
+  
+  This pipeline example is available [here](https://github.com/bionode/bionode-watermill/blob/master/examples/pipelines/two-mappers/pipeline.js)
+
+## The Pipeline
+### Fetching sequence data
+
+First, we will define a variable `config` that defines the **name** and
+ **URL** of the reference genome of _Streptococcus pneumoniae_. Also this 
+ `config` also has the accession of the desired reads (`sraAccession`).
+  
+```javascript
+const config = {
+  name: 'Streptococcus pneumoniae',
+  sraAccession: 'ERR045788',
+  referenceURL: 'http://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/007/045/' +
+  'GCF_000007045.1_ASM704v1/GCF_000007045.1_ASM704v1_genomic.fna.gz'
+}
+```
+
+Then we will download both the reference genome as well as the sample reads.
+The first one we download using the `config.referenceURL` previously defined:
+
+```javascript
+// first lets get the reference genome for our mapping
+const getReference = task({
+  params: { url: config.referenceURL },
+  output: '*_genomic.fna.gz',
+  name: 'Download reference genome for ${config.name}'
+}, ({ params, dir }) => {
+  const { url } = params
+  const outfile = url.split('/').pop()
+
+  // essentially curl -O
+  return request(url).pipe(fs.createWriteStream(dir + '/' + outfile))
+})
+```
+
+While for the second one we will use bionode-ncbi to download the reads:
+
+```javascript
+//then get samples to work with
+const getSamples = task({
+  params: {
+    db: 'sra',
+    accession: config.sraAccession
+  },
+  output: '**/*.sra',
+  dir: process.cwd(), // Set dir to resolve input/output from
+  name: 'Download SRA ${config.sraAccession}'
+}, ({ params }) => `bionode-ncbi download ${params.db} ${params.accession}`
+)
+```
+
+Then since the download from SRA returns a `.sra` file, we have to process with
+ `fastq-dump` (sra-toolkit) it in order to get the ` .fastq.gz` files 
+ contained in 
+ this sra accession.
+ 
+ ```javascript
+// extract the samples from fastq.gz
+const fastqDump = task({
+  input: '**/*.sra',
+  output: [1, 2].map(n => `*_${n}.fastq.gz`),
+  name: 'fastq-dump **/*.sra'
+}, ({ input }) => `fastq-dump --split-files --skip-technical --gzip ${input}`
+)
+```
+
+Now, note that we are getting reference and samples in parallel using 
+**junction** orchestrator:
+
+```javascript
+// === PIPELINE ===
+
+const pipeline = join(
+  junction(
+      getReference,
+      join(getSamples,fastqDump)
+  ),
+  fork(
+    join(IndexReferenceBwa, bwaMapper),
+    join(indexReferenceBowtie2, bowtieMapper)
+  )
+)
+```
+
+This means that only after both reference and samples have finished 
+downloading, and in the case of samples being extracted from `.sra` file, the
+ remaining tasks will be executed. In this case the tasks within the **fork**
+  orchestrator will be performed after the **junction**.
+
+### Mapping
+
+Now, in fact **fork** isn't really necessary in the above example, however, 
+the idea is for you to continue on your own after this example. For instance 
+you may try to run `samtools faidx`  after the fork, which will render two 
+independent results, one for `bowtie` results and another for `bwa` results. 
+The pipeline would look something like this:
+
+```javascript
+// === PIPELINE ===
+
+const pipeline = join(
+  junction(
+      getReference,
+      join(getSamples,fastqDump)
+  ),
+  fork(
+    join(IndexReferenceBwa, bwaMapper),
+    join(indexReferenceBowtie2, bowtieMapper)
+  ),
+  samtoolsFaidx
+)
+```
+
+But, back to mapping! In this example we set up mapping in two types of tasks:
+
+* Reference indexing (`IndexReferenceBwa` and `indexReferenceBowtie2`).
+* Mapping (`bwaMapper` and `bowtieMapper`).
+
+Then, we 'forced' each indexing to run before each mapping approach by using 
+**join** orchestrator. You can check the definition of these tasks 
+[here](https://github.com/bionode/bionode-watermill/blob/master/examples
+/pipelines/two-mappers/pipeline.js#L66-L114).
+
+### The challenge!
+
+Now that you have tasted a simple pipeline that is able to map sequences from
+ NCBI SRA against a reference genome using two different mappers, feel free 
+ to test some usages with the output files of the mapping.
+ One useful example would be to use samtools to obtain the 'mapping depth' of
+  your mapping results. Something like: `samtools faidx` --> `samtools view` 
+  --> `samtools sort` --> `samtools index` --> `samtools depth`.
+
+

--- a/examples/pipelines/two-mappers/README.md
+++ b/examples/pipelines/two-mappers/README.md
@@ -12,16 +12,18 @@ First of all, you will need to clone bionode-watermill if you haven't done it
 
 Also, you need to have installed:
 
-1) **[bionode-ncbi](https://github.com/bionode/bionode-ncbi)** (however, this 
+1) **Node.js** version 7 or higher.
+2) **[bionode-ncbi](https://github.com/bionode/bionode-ncbi)** (however, this 
 one is not really necessary assuming that you 
 run the examples from within the bionode-watermill folders).
-2) **[sra-toolkit](https://www.ncbi.nlm.nih.gov/books/NBK158900/)**
-3) **[bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml)**
-4) **[bwa](http://bio-bwa.sourceforge.net/)**
-5) **[samtools](http://samtools.sourceforge.net/)**
+3) **[sra-toolkit](https://www.ncbi.nlm.nih.gov/books/NBK158900/)**
+4) **[bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml)**
+5) **[bwa](http://bio-bwa.sourceforge.net/)**
+6) **[samtools](http://samtools.sourceforge.net/)**
 
-However, don't worry you can use this docker image instead. (**under 
-construction**).
+However, don't worry you can use [this](https://github.com/tiagofilipe12/docker-watermill-tutorial) 
+docker image instead. You can also check the [docker hub repo](https://hub.docker.com/r/tiagofilipe12/docker-watermill-tutorial/) 
+if you prefer.
 
 ## What for?
 
@@ -32,7 +34,7 @@ _Streptococcus pneumoniae_ and the SRA accession 'ERR045788', and then map the
   according to your own needs (which might be a good starting point to 
   understand the mechanics of bionode-watermill).
   
-  This example pipeline is available [here](https://github.com/bionode/bionode-watermill/blob/master/examples/pipelines/two-mappers/pipeline.js)
+  This example pipeline is available [here](https://github.com/bionode/bionode-watermill/blob/master/examples/pipelines/two-mappers/pipeline.js).
 
 ## The Pipeline
 ### Fetching sequence data

--- a/examples/pipelines/two-mappers/README.md
+++ b/examples/pipelines/two-mappers/README.md
@@ -153,8 +153,7 @@ But, back to mapping! In this example we set up mapping in two types of tasks:
 
 Then, we 'forced' each indexing to run before each mapping approach by using 
 **join** orchestrator. You can check the definition of these tasks 
-[here](https://github.com/bionode/bionode-watermill/blob/master/examples
-/pipelines/two-mappers/pipeline.js#L66-L114).
+[here](https://github.com/bionode/bionode-watermill/blob/master/examples/pipelines/two-mappers/pipeline.js#L66-L114).
 
 ### The challenge! :boom:
 

--- a/examples/pipelines/two-mappers/README.md
+++ b/examples/pipelines/two-mappers/README.md
@@ -32,7 +32,7 @@ _Streptococcus pneumoniae_ and the SRA accession 'ERR045788', and then map the
   according to your own needs (which might be a good starting point to 
   understand the mechanics of bionode-watermill).
   
-  This pipeline example is available [here](https://github.com/bionode/bionode-watermill/blob/master/examples/pipelines/two-mappers/pipeline.js)
+  This example pipeline is available [here](https://github.com/bionode/bionode-watermill/blob/master/examples/pipelines/two-mappers/pipeline.js)
 
 ## The Pipeline
 ### Fetching sequence data

--- a/examples/pipelines/two-mappers/README.md
+++ b/examples/pipelines/two-mappers/README.md
@@ -166,3 +166,5 @@ Now that you have tasted a simple pipeline that is able to map sequences from
   --> `samtools sort` --> `samtools index` --> `samtools depth`.
 
 
+If you run into trouble, you can find an example of this pipeline 
+[here](https://github.com/bionode/bionode-watermill/tree/master/examples/pipelines/two-mappers/pipeline_lazy.js).

--- a/examples/pipelines/two-mappers/README.md
+++ b/examples/pipelines/two-mappers/README.md
@@ -156,7 +156,7 @@ Then, we 'forced' each indexing to run before each mapping approach by using
 [here](https://github.com/bionode/bionode-watermill/blob/master/examples
 /pipelines/two-mappers/pipeline.js#L66-L114).
 
-### The challenge!
+### The challenge! :boom:
 
 Now that you have tasted a simple pipeline that is able to map sequences from
  NCBI SRA against a reference genome using two different mappers, feel free 

--- a/examples/pipelines/two-mappers/pipeline_lazy.js
+++ b/examples/pipelines/two-mappers/pipeline_lazy.js
@@ -1,0 +1,191 @@
+'use strict'
+
+// === WATERMILL ===
+const {
+  task,
+  join,
+  junction,
+  fork
+} = require('../../..')
+
+// === MODULES ===
+
+const fs = require('fs')
+const path = require('path')
+
+const request = require('request')
+const ncbi = require('bionode-ncbi')
+
+// === CONFIG ===
+
+// specifies the number of threads to use by mappers
+const THREADS = parseInt(process.env.WATERMILL_THREADS) || 2
+
+const config = {
+  name: 'Streptococcus pneumoniae',
+  sraAccession: 'ERR045788',
+  referenceURL: 'http://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/007/045/' +
+  'GCF_000007045.1_ASM704v1/GCF_000007045.1_ASM704v1_genomic.fna.gz'
+}
+
+// === TASKS ===
+
+// first lets get the reference genome for our mapping
+const getReference = task({
+  params: { url: config.referenceURL },
+  output: '*_genomic.fna.gz',
+  name: 'Download reference genome for ${config.name}'
+}, ({ params, dir }) => {
+  const { url } = params
+  const outfile = url.split('/').pop()
+
+  // essentially curl -O
+  return request(url).pipe(fs.createWriteStream(dir + '/' + outfile))
+})
+
+//then get samples to work with
+const getSamples = task({
+    params: {
+      db: 'sra',
+      accession: config.sraAccession
+    },
+    output: '**/*.sra',
+    dir: process.cwd(), // Set dir to resolve input/output from
+    name: 'Download SRA ${config.sraAccession}'
+  }, ({ params }) => `bionode-ncbi download ${params.db} ${params.accession}`
+)
+
+// extract the samples from fastq.gz
+const fastqDump = task({
+    input: '**/*.sra',
+    output: [1, 2].map(n => `*_${n}.fastq.gz`),
+    name: 'fastq-dump **/*.sra'
+  }, ({ input }) => `fastq-dump --split-files --skip-technical --gzip ${input}`
+)
+
+// then index using first bwa ...
+const IndexReferenceBwa = task({
+  input: '*_genomic.fna.gz',
+  output: ['amb', 'ann', 'bwt', 'pac', 'sa'].map(suffix =>
+    `*_genomic.fna.gz.${suffix}`),
+  name: 'bwa index *_genomic.fna.gz'
+}, ({ input }) => `bwa index ${input}`)
+
+// and bowtie2
+
+const indexReferenceBowtie2 = task({
+    input: '*_genomic.fna.gz',
+    output: ['1.bt2', '2.bt2', '3.bt2', '4.bt2', 'rev.1.bt2',
+      'rev.2.bt2'].map(suffix => `bowtie_index.${suffix}`),
+    params: { output: 'bowtie_index' },
+    name: 'bowtie2-build -q uncompressed.fa bowtie_index'
+  }, ({ params, input }) => `gunzip -c ${input} > uncompressed.fa | bowtie2-build -q uncompressed.fa ${params.output}`
+  /* for bowtie we had to uncompress the .fna.gz file first before building
+   the reference */
+)
+
+// now use mappers with bwa
+
+const bwaMapper = task({
+    input: {
+      reference: '*_genomic.fna.gz',
+      reads:[1, 2].map(n => `*_${n}.fastq.gz`),
+      indexFiles: ['amb', 'ann', 'bwt', 'pac', 'sa'].map(suffix =>
+        `*_genomic.fna.gz.${suffix}`) //pass index files to bwa mem
+    },
+    output: '*.sam',
+    params: { output: 'bwa_output.sam' },
+    name: 'Mapping with bwa...'
+  }, ({ input, params }) => `bwa mem -t ${THREADS} ${input.reference} ${input.reads[0]} ${input.reads[1]} > ${params.output}`
+)
+
+// and with bowtie2
+
+const bowtieMapper = task({
+    input: {
+      reference: '*_genomic.fna.gz',
+      reads:[1, 2].map(n => `*_${n}.fastq.gz`),
+      indexFiles: ['1.bt2', '2.bt2', '3.bt2', '4.bt2', 'rev.1.bt2',
+        'rev.2.bt2'].map(suffix => `bowtie_index.${suffix}`) //pass index files to
+      // bowtie2
+    },
+    output: '*.sam',
+    params: { output: 'bowtie2_output.sam' },
+    name: 'Mapping with bowtie2...'
+  }, ({ input, params }) => `bowtie2 -p ${THREADS} -x bowtie_index -1 ${input.reads[0]} -2 ${input.reads[1]} -S ${params.output}`
+)
+
+// SAMTOOLS tasks
+
+const samtoolsFaidx = task({
+  input: '*_genomic.fna.gz',
+  output: '*.fasta.fai',
+  name: 'generating .fai for reference'
+}, ({ input }) => `gunzip -c ${input} > reference.fasta && samtools faidx reference.fasta`
+)
+
+const samtoolsView = task({
+  input: {
+    samfile: '*.sam',
+    faidxfile: '*.fasta.fai'
+  },
+  output: '*.bam',
+  name: 'Samtools View'
+}, ({ input }) => {
+  const outputfile = input.samfile.slice(0,-3) + 'bam'  /* use same name as
+   input but replace the final extension to the string to bam. In this case
+    if we hardcode the name, it will render an error since two outputs will
+     match the same name */
+  return `samtools view -b -S -t ${input.faidxfile} -@ ${THREADS} -o ${outputfile} ${input.samfile}`
+})
+
+const samtoolsSort = task({
+  input: '*.bam',
+  output: '*.sorted.bam'
+}, ({ input }) => {
+  const outputsorted = input.slice(0,-3) + 'sorted.bam' /* use same name as
+   input but replace the final extension to the string to sorted.bam. */
+  return `samtools sort -@ ${THREADS} -o ${outputsorted} ${input}`
+})
+
+const samtoolsIndex = task({
+  input: '*.sorted.bam',
+  output: '*.bai'
+}, ({ input }) => `samtools index ${input}` /* this will generate a .bai
+ file based on the input file name and thus there is no need to handle the
+  file extension for the next task */
+)
+
+const samtoolsDepth = task({
+  input: {
+    indexfile: '*.bai', /* index is needed although it is not an input to
+     the command of samtools depth */
+    sortedfile: '*.sorted.bam'
+  },
+  output: '*.txt'
+}, ({ input }) => {
+  const depthoutput = input.sortedfile.slice(0,-11) + '_depth.txt'
+  return `samtools depth ${input.sortedfile} > ${depthoutput}`
+})
+
+
+// === PIPELINE ===
+
+const pipeline = join(
+  junction(
+    getReference,
+    join(getSamples,fastqDump)
+  ),
+  samtoolsFaidx, /* since this will be common to both mappers, there is no
+   need to be executed after fork duplicating the effort. */
+  fork(
+    join(IndexReferenceBwa, bwaMapper),
+    join(indexReferenceBowtie2, bowtieMapper)
+  ),
+  /* here the pipeline will break into two distinct branches, one for each
+   mapping approach used. */
+  samtoolsView, samtoolsSort, samtoolsIndex, samtoolsDepth
+)
+
+// actual run pipelines and return results
+pipeline().then(results => console.log('PIPELINE RESULTS: ', results))


### PR DESCRIPTION
This PR adds a README.md to `examples/pipelines/two-mappers` that can be used as a walk-through guide on how to build a similar pipeline or even to run that pipeline. Also, adds a pipeline_lazy.js that is intended to provide a solution to the proposed challenge in the README.md.