### PR TITLE
Fixed issue with logging of task name to stdout

### DIFF
--- a/lib/orchestrators/fork.js
+++ b/lib/orchestrators/fork.js
@@ -24,12 +24,12 @@ function fork(...tasks) {
       }).asCallback(cb)
   }
 
-  forkInvocator.info = {
-    uid: 'generic fork uid',
-    name: 'generic fork name',
-    type: 'fork',
-    tasks
-  }
+  //forkInvocator.info = {
+  //  uid: 'generic fork uid',
+  //  name: 'generic fork name',
+  // type: 'fork',
+  //  tasks
+  //}
 
   return forkInvocator
 }

--- a/lib/orchestrators/fork.js
+++ b/lib/orchestrators/fork.js
@@ -24,12 +24,12 @@ function fork(...tasks) {
       }).asCallback(cb)
   }
 
-  //forkInvocator.info = {
-  //  uid: 'generic fork uid',
-  //  name: 'generic fork name',
-  // type: 'fork',
-  //  tasks
-  //}
+  forkInvocator.info = {
+    uid: 'generic fork uid',
+    name: 'generic fork name',
+    type: 'fork',
+    tasks
+  }
 
   return forkInvocator
 }

--- a/lib/orchestrators/join.js
+++ b/lib/orchestrators/join.js
@@ -17,9 +17,10 @@ const join = (dispatch) => {
 
       // TODO better checking if task/join/junction/fork
       if (task.info) {
-        if (task.info.props) {
-          console.log('Joining to task: ' + task.info.props.name)
-        }
+        //if (task.info.props) {
+        //  console.log('Joining to task: ' + task.info.props.name)
+        //}
+        console.log('Joining to task: ' + _.get(task, 'info.props.name'))
         // Add this task to list of uids for this join
         uids.push(task.info.uid)
         if (task.info.type === 'fork') {

--- a/lib/orchestrators/join.js
+++ b/lib/orchestrators/join.js
@@ -17,7 +17,7 @@ const join = (dispatch) => {
 
       // TODO better checking if task/join/junction/fork
       if (task.info) {
-        console.log('Joining to task: ' + task.info.name)
+        console.log('Joining to task: ' + task.info.props.name)
         // Add this task to list of uids for this join
         uids.push(task.info.uid)
 

--- a/lib/orchestrators/join.js
+++ b/lib/orchestrators/join.js
@@ -17,10 +17,11 @@ const join = (dispatch) => {
 
       // TODO better checking if task/join/junction/fork
       if (task.info) {
-        console.log('Joining to task: ' + task.info.props.name)
+        if (task.info.props) {
+          console.log('Joining to task: ' + task.info.props.name)
+        }
         // Add this task to list of uids for this join
         uids.push(task.info.uid)
-
         if (task.info.type === 'fork') {
           // console.log('ABOUT TO FORK, currentCtx is: ', currentCtx)
           // We now need to duplicate everything after for as many tasks in fork()


### PR DESCRIPTION
Previously `console.log('Joining to task: ' + task.info.name)` would render something like: 
`Joining to task: undefined`. However, the task name is stored in `task.info.props.name` instead.