### PR TITLE
implemented redux-logger given an environmental variable

### DIFF
--- a/lib/watermill.js
+++ b/lib/watermill.js
@@ -1,13 +1,26 @@
 'use strict'
 
 const { createStore, applyMiddleware } = require('redux')
+const createLogger = require('redux-logger')
 const thunk = require('redux-thunk').default
 const rootReducer = require('./reducers')
 
 const createSagaMW = require('redux-saga').default
 const sagaMW = createSagaMW()
+const logger = createLogger()
 
-const store = createStore(rootReducer, applyMiddleware(thunk, sagaMW))
+// default middlewares
+let middlewares = [thunk, sagaMW]
+
+// if Environmental variable REDUX_LOGGER is 1 then...
+const loggerEnv = process.env.REDUX_LOGGER
+// for now call REDUX_LOGGER=1 before executing a pipeline
+// REDUX_LOGGER=1 node pipeline.js
+if (loggerEnv === '1') {
+  middlewares.push(logger)
+}
+
+const store = createStore(rootReducer, applyMiddleware(...middlewares))
 
 const rootSaga = require('./sagas')
 sagaMW.run(rootSaga)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "isstream": "^0.1.2",
     "istanbul": "^0.4.4",
     "mocha": "^2.5.3",
-    "redux-logger": "^2.6.1",
+    "redux-logger": "^2.10.2",
     "request": "^2.72.0",
     "split": "^1.0.0",
     "stream-assert": "^2.0.3",


### PR DESCRIPTION
In this PR implemented a check for an environmental variable that changes the middlewares within ` lib/watermill.js`. If `REDUX_LOGGER=1`  in environment the pipeline will execute `redux-logger`. 
Also redux-logger package was updated in this PR.