### PR TITLE
Added operation command to graphson

### DIFF
--- a/lib/constants/default-task-state.js
+++ b/lib/constants/default-task-state.js
@@ -39,6 +39,8 @@ exports.defaultTask = {
   input: null,
   output: null,
   operation: null,
+  operationString: null,  // just one is really necessary between this and
+  // task.js definition
   status: statusTypes.STATUS_CREATED,
   created: null,
   validated: false,

--- a/lib/lifecycle/create-operation.js
+++ b/lib/lifecycle/create-operation.js
@@ -66,7 +66,7 @@ const createOperation = (taskState, linkedResolvedInput, operationCreator, logge
           emit: (channel, content, tabLevel = 0) => logger.emit(channel, content, logger.depth + tabLevel)
         }),
         // dir,
-        operationString: operationCreator
+        operationString: operation
       })
     } else {
       resolve({

--- a/lib/reducers/collection.js
+++ b/lib/reducers/collection.js
@@ -125,7 +125,16 @@ const jsonifyGraph = (graph, obj = {}) => {
 
 function addOutputHandler (state, action) {
   // TODO remove duplicate code b/w this, and creating the next trajection in join
-  const { type, uid, resolvedOutput, resolvedInput, params, context, name } = action
+  const {
+    type,
+    uid,
+    resolvedOutput,
+    resolvedInput,
+    params,
+    context,
+    name,
+    operationString
+  } = action
   const { trajectory } = context
   // console.log(`trajectory for ${uid}: `, trajectory)
   // console.log(`output for ${uid}: `, output)
@@ -144,7 +153,15 @@ function addOutputHandler (state, action) {
   // if resolvedInput doesn't exist and it is outputted to the graph this
   // breaks the pipeline
   if (resolvedInput) {
-    const tempVertex = { type, name, resolvedInput, resolvedOutput, params }
+    // node that in ES6 { type } === { type: type }
+    const tempVertex = {
+      type,
+      name,
+      resolvedInput,
+      resolvedOutput,
+      params,
+      operationString //this will pass operationString even if it is undefined
+    }
     graph.addNewVertex(uid, tempVertex) //addNewVertex(key, [value])
   } else {
     const tempVertex = { type, name, resolvedOutput, params }
@@ -202,7 +219,8 @@ reducer.addOutput = (uid, taskState) => ({
   resolvedOutput: taskState.resolvedOutput,
   resolvedInput: taskState.resolvedInput,
   context: taskState.context,
-  params: taskState.params
+  params: taskState.params,
+  operationString: taskState.operationString
 })
 
 reducer.ADD_JUNCTION_VERTEX = ADD_JUNCTION_VERTEX

--- a/lib/reducers/task.js
+++ b/lib/reducers/task.js
@@ -52,6 +52,8 @@ const initTask = (task) => {
     input: null,
     output: null,
     operation: null,
+    operationString: null, //just one is really necessary between this and
+    // defaut-task-state.js definition
     status: STATUS_CREATED,
     created: null,
     validated: false,

--- a/lib/reducers/tasks.js
+++ b/lib/reducers/tasks.js
@@ -25,6 +25,8 @@ const SUCCESS_VALIDATING_OUTPUT = 'task/success_validating-output'
 
 const APPEND_TO_LOG = 'task/append-to-log'
 
+const SET_OPERATION_STRING = 'task/set-operation-string'
+
 // Internal Methods
 
 /**
@@ -81,6 +83,9 @@ const taskReducer = (state = {}, action) => {
       break
     case SUCCESS_VALIDATING_OUTPUT:
       return Object.assign({}, state, { status: 'POST_VALIDATION', validated: true })
+      break
+    case SET_OPERATION_STRING:
+      return Object.assign({}, state, {operationString: action.operationString})
       break
     case APPEND_TO_LOG:
       const { channel, content } = action
@@ -171,6 +176,10 @@ reducer.SUCCESS_RESOLVE_INPUT = SUCCESS_RESOLVE_INPUT
 reducer.startOperation = (uid) => ({ type: START_OPERATION, uid })
 reducer.successOperation = (uid) => ({ type: SUCCESS_OPERATION, uid })
 reducer.SUCCESS_OPERATION = SUCCESS_OPERATION
+
+// passes operationString to action and next taskState
+reducer.setOperationString = (uid, operationString) => ({ type:SET_OPERATION_STRING, uid, operationString })
+reducer.SET_OPERATION_STRING = SET_OPERATION_STRING
 
 reducer.startResolveOutput = (uid) => ({ type: START_RESOLVE_OUTPUT, uid })
 reducer.START_RESOLVE_INPUT = START_RESOLVE_INPUT

--- a/lib/reducers/tasks.js
+++ b/lib/reducers/tasks.js
@@ -85,7 +85,7 @@ const taskReducer = (state = {}, action) => {
       return Object.assign({}, state, { status: 'POST_VALIDATION', validated: true })
       break
     case SET_OPERATION_STRING:
-      return Object.assign({}, state, {operationString: action.operationString})
+      return Object.assign({}, state, { operationString: action.operationString })
       break
     case APPEND_TO_LOG:
       const { channel, content } = action

--- a/lib/sagas/lifecycle.js
+++ b/lib/sagas/lifecycle.js
@@ -52,7 +52,9 @@ const {
   successValidatatingOutput,
   SUCCESS_VALIDATING_OUTPUT,
   appendToLog,
-  APPEND_TO_LOG
+  APPEND_TO_LOG,
+  setOperationString,
+  SET_OPERATION_STRING
 } = require('../reducers/tasks.js')
 
 const { addOutput } = require('../reducers/collection.js')
@@ -169,6 +171,8 @@ function* lifecycle (action) {
         yield select(selectTask(uid)), linkedResolvedInput, operationCreator, nestedLogger(1)
       )
       // console.log('operation string: ', ops.operationString)
+      // this pushes operationString to taskState
+      yield put(setOperationString(uid, ops.operationString))
       const settled = yield call(settleOperation, ops.operation)
       // console.log('post settled: ', settled)
       yield put(successOperation(uid))

--- a/viz/index.html
+++ b/viz/index.html
@@ -120,7 +120,8 @@
 - Output(s): ${JSON.stringify(d.values.resolvedOutput)}
 - Input(s): ${JSON.stringify(d.values.resolvedInput)}
 - params: ${JSON.stringify(d.values.params)}
-- Output folder: ${miniUid}` })
+- Output folder: ${miniUid}
+- Cmd: ${JSON.stringify(d.values.operationString)}` })
 //this will not handle properly bionode-ncbi output folders
 
     simulation


### PR DESCRIPTION
This PR adds `operationString` to task reducer and subsequently to graphson file and visualization. If it is a string passed as command to shell it will be outputed to `graphson`, otherwise it will not be included and thus it will render `undefined` in visualization and will be absent from `graphson.json`. This behavior can be simplified but for now this is cool, I think.