### PR TITLE
edits to two-mappers pipeline and removed of redundant defaultTask

### DIFF
--- a/examples/pipelines/two-mappers/README.md
+++ b/examples/pipelines/two-mappers/README.md
@@ -112,6 +112,7 @@ const pipeline = join(
       getReference,
       join(getSamples,fastqDump)
   ),
+  gunzipIt,
   fork(
     join(IndexReferenceBwa, bwaMapper),
     join(indexReferenceBowtie2, bowtieMapper)
@@ -140,6 +141,7 @@ const pipeline = join(
       getReference,
       join(getSamples,fastqDump)
   ),
+  gunzipIt,
   fork(
     join(IndexReferenceBwa, bwaMapper),
     join(indexReferenceBowtie2, bowtieMapper)

--- a/examples/pipelines/two-mappers/pipeline_lazy.js
+++ b/examples/pipelines/two-mappers/pipeline_lazy.js
@@ -63,28 +63,36 @@ const fastqDump = task({
   }, ({ input }) => `fastq-dump --split-files --skip-technical --gzip ${input}`
 )
 
-// then index using first bwa ...
-const IndexReferenceBwa = task({
+// first lets uncompress the gz
+const gunzipIt = task({
   input: '*_genomic.fna.gz',
+  output: '*.fa',
+  params: { output: 'uncompressed.fa' }
+}, ({ params, input}) => `gunzip -c ${input} > ${params.output}`
+)
+
+// then index using first bwa ...
+const indexReferenceBwa = task({
+  input: '*.fa',
   output: {
     indexFile: ['amb', 'ann', 'bwt', 'pac', 'sa'].map(suffix =>
-      `bwa_index.fa.${suffix}`),
-    reference: 'bwa_index.fa' //names must match for bwa - between reference
+      `bwa_index.${suffix}`),
+    //reference: 'bwa_index.fa' //names must match for bwa - between reference
     // and index files
   },
-  params: { output: 'bwa_index.fa' },
+  //params: { output: 'bwa_index.fa' },
   name: 'bwa index bwa_index.fa -p bwa_index'
-}, ({ params, input }) => `gunzip -c ${input} > bwa_index.fa && bwa index bwa_index.fa -p ${params.output}`)
+}, ({ input }) => `bwa index ${input} -p bwa_index`)
 
 // and bowtie2
 
 const indexReferenceBowtie2 = task({
-    input: '*_genomic.fna.gz',
+    input: '*.fa',
     output: ['1.bt2', '2.bt2', '3.bt2', '4.bt2', 'rev.1.bt2',
       'rev.2.bt2'].map(suffix => `bowtie_index.${suffix}`),
     params: { output: 'bowtie_index' },
     name: 'bowtie2-build -q uncompressed.fa bowtie_index'
-  }, ({ params, input }) => `gunzip -c ${input} > uncompressed.fa && bowtie2-build -q uncompressed.fa ${params.output}`
+  }, ({ params, input }) => `bowtie2-build -q ${input} ${params.output}`
   /* for bowtie we had to uncompress the .fna.gz file first before building
    the reference */
 )
@@ -93,15 +101,15 @@ const indexReferenceBowtie2 = task({
 
 const bwaMapper = task({
     input: {
-      reference: 'bwa_index.fa',
+      //reference: '*.fa',
       reads:[1, 2].map(n => `*_${n}.fastq.gz`),
       indexFiles: ['amb', 'ann', 'bwt', 'pac', 'sa'].map(suffix =>
-        `bwa_index.fa.${suffix}`) //pass index files to bwa mem
+        `bwa_index.${suffix}`) //pass index files to bwa mem
     },
     output: '*.sam',
     params: { output: 'bwa_output.sam' },
     name: 'Mapping with bwa...'
-  }, ({ input, params }) => `bwa mem -t ${THREADS} ${input.reference} ${input.reads[0]} ${input.reads[1]} > ${params.output}`
+  }, ({ input, params }) => `bwa mem -t ${THREADS} bwa_index ${input.reads[0]} ${input.reads[1]} > ${params.output}`
 )
 
 // and with bowtie2
@@ -181,10 +189,11 @@ const pipeline = join(
     getReference,
     join(getSamples,fastqDump)
   ),
-  samtoolsFaidx, /* since this will be common to both mappers, there is no
+  samtoolsFaidx, gunzipIt, /* since this will be common to both mappers, there
+   is no
    need to be executed after fork duplicating the effort. */
   fork(
-    join(IndexReferenceBwa, bwaMapper),
+    join(indexReferenceBwa, bwaMapper),
     join(indexReferenceBowtie2, bowtieMapper)
   ),
   /* here the pipeline will break into two distinct branches, one for each

--- a/lib/reducers/task.js
+++ b/lib/reducers/task.js
@@ -9,6 +9,7 @@ const asyncDone = require('async-done')
 const applicator = require('../utils/applicator.js')
 const defaultConfig = require('./config.js').defaultState
 const { hash, tab } = require('../utils')
+const { defaultTask } = require('../constants/default-task-state.js')
 
 // Actions
 const CHECK_RESUMABLE = 'task/check-resumable'
@@ -37,29 +38,6 @@ const initTask = (task) => {
   // null values NEED to be set
   // except for container, resolvedInput, resolvedOuput, operation
   // TODO a "deepObjectAssign", so that properties like params can be extended
-  const defaultTask = {
-    threads: defaultConfig.threads,
-    container: defaultConfig.container,
-    resume: defaultConfig.resume,
-    uid: null,
-    hashes: {
-      input: null,
-      output: null,
-      params: null
-    },
-    name: 'Unnamed Task',
-    dir: null,
-    input: null,
-    output: null,
-    operation: null,
-    operationString: null, //just one is really necessary between this and
-    // defaut-task-state.js definition
-    status: STATUS_CREATED,
-    created: null,
-    validated: false,
-    params: {},
-    trajectory: []
-  }
 
   task = Object.assign({}, defaultTask, task, { created: Date.now() })
   const hashes = {


### PR DESCRIPTION
In this PR I made some changes to two-mappers example pipelines in order to avoid the usage of shell pipe, since for reproducibility isolating tasks would be better.
Also, `defaultTask` state was removed from `lib/reducers/task.js` since it is duplicated in `lib/constants/default-task-state.js` and was replaced by an import from the latter.