### PR TITLE
added task.name to uid generator

### DIFF
--- a/lib/lifecycle/generate-uid.js
+++ b/lib/lifecycle/generate-uid.js
@@ -13,8 +13,8 @@ const { defaultHashes } = require('../constants/default-task-state.js')
  *
  * @returns {Object} of the structure { uid, hashes: { input, output, params } }
  */
-const generateUid = ({ input, output, params }) => {
-  const userIOP = { input, output, params }
+const generateUid = ({ input, output, params, name }) => {
+  const userIOP = { input, output, params, name }
 
   // Clean out undefined or null values
   // Thus is the user passes input, output, but no params
@@ -35,7 +35,7 @@ const generateUid = ({ input, output, params }) => {
   )
 
   // uid is a hash of hashes
-  const uid = hash(hashes.input + hashes.output + hashes.params)
+  const uid = hash(hashes.input + hashes.output + hashes.params + hashes.name)
 
   const result = {
     uid,


### PR DESCRIPTION
In this PR I added a simple fix to a problem with duplicated uids when tasks are duplicated. Please check this [journal entry](https://github.com/bionode/GSoC17/blob/master/Journal/Week_9.md#how-to-merge-results-from-different-pipeline-branches) since it has a detailed description on the issue related with this and on how I tried to solve it. 

This duplication of uids not only prevented pipeline branches to run the same task, even if we declare different `const` for each task (with same contents), but also when branching with `junction` using same task it will execute with the first hit regardless of the branch it came from.