### PR TITLE
Add another test for fork within fork wrapped in join

### DIFF
--- a/lib/orchestrators/join.js
+++ b/lib/orchestrators/join.js
@@ -76,7 +76,21 @@ const join = (dispatch, logger) => {
             if (forkee.info.props) {
               // this handles if fork is within fork without join wrapping
               // the inner fork
-              if (outermostTasks.info !== downStreamTasks.info) {
+              const sumOuterMostTasks = outermostTasks.map(
+                t => t.info.operationCreator
+              ).reduce((a, b) => hash(a + b), 0)
+
+              // creates an hash for all downStreamTasks
+              const sumDownStreamTasks = downStreamTasks.map(
+                t => t.info.operationCreator    // it uses task operationCreator
+              ).reduce((a, b) => hash(a + b), 0)
+              // creates an hash for all outermostTasks
+              //console.log('taskstotest:',
+              // sumOuterMostTasks,sumDownStreamTasks)
+              // then checks if the hash is the same
+              // it will be the same if fork is followed by another fork
+              // it will be different if fork is wrapped by a join inside a fork
+              if (sumOuterMostTasks !== sumDownStreamTasks) {
                 const newdownStreamTasks = taskCreationDispatcher(dispatch, downStreamTasks, task.info.uid, forkee.info.uid, upStreamUids)
                 const newOutermostTasks = taskCreationDispatcher(dispatch, outermostTasks, task.info.uid, forkee.info.uid, upStreamUids)
                 // notice that if not within a fork it creates a lineage

--- a/lib/orchestrators/join.js
+++ b/lib/orchestrators/join.js
@@ -108,13 +108,37 @@ const join = (dispatch, logger) => {
             } else if (forkee.info.type === 'fork') {
               // handles everything that is not task out of the scope of
               // firstFork instance
-              const newdownStreamTasks = taskCreationDispatcher(dispatch, downStreamTasks, task.info.uid, forkee.info.uid, upStreamUids)
-              const newOutermostTasks = taskCreationDispatcher(dispatch, outermostTasks, task.info.uid, forkee.info.uid, upStreamUids)
-              // if a task is found for outer fork it will dispatch the outer
-              // task as newdownStreamTasks, otherwise it will concat the other
-              // orchestrators
-              const lineage = [forkee].concat(newdownStreamTasks).concat(newOutermostTasks)
-              lineageGetter(dispatch, lineage, joinages)
+              // this handles if fork is within fork without join wrapping
+              // the inner fork
+              const sumOuterMostTasks = outermostTasks.map(
+                t => t.info.operationCreator
+              ).reduce((a, b) => hash(a + b), 0)
+
+              // creates an hash for all downStreamTasks
+              const sumDownStreamTasks = downStreamTasks.map(
+                t => t.info.operationCreator    // it uses task operationCreator
+              ).reduce((a, b) => hash(a + b), 0)
+              // creates an hash for all outermostTasks
+              //console.log('taskstotest:',
+              // sumOuterMostTasks,sumDownStreamTasks)
+              // then checks if the hash is the same
+              // it will be the same if fork is followed by another fork
+
+              if (sumOuterMostTasks !== sumDownStreamTasks) {
+                const newdownStreamTasks = taskCreationDispatcher(dispatch, downStreamTasks, task.info.uid, forkee.info.uid, upStreamUids)
+                const newOutermostTasks = taskCreationDispatcher(dispatch, outermostTasks, task.info.uid, forkee.info.uid, upStreamUids)
+                // notice that if not within a fork it creates a lineage
+                // with the joint tasks plus the outermostTask with a new uid
+                const lineage = [forkee].concat(newdownStreamTasks).concat(newOutermostTasks)
+                lineageGetter(dispatch, lineage, joinages)
+              } else { // if a fork is found within another fork
+                // this avoids the duplication of the last task
+                const newOutermostTasks = taskCreationDispatcher(dispatch, outermostTasks, task.info.uid, forkee.info.uid, upStreamUids)
+                // in the case of fork it simply adds to the forkee task the
+                // outermost task
+                const lineage = [forkee].concat(newOutermostTasks)
+                lineageGetter(dispatch, lineage, joinages)
+              }
             } else {
               // for join and junction immediately after a fork in order to
               // not duplicate last task

--- a/test/fork.spec.js
+++ b/test/fork.spec.js
@@ -31,7 +31,7 @@ describe('fork', function() {
   // TODO setup/teadown
   it.skip('should return an array of results', function (done) {
     fork(ls, lsAL)().then((results) => {
-      console.log('results: ', results)
+      //console.log('results: ', results)
       assert.isOk(_.isArray(results))
       done()
     })
@@ -47,7 +47,7 @@ describe('fork', function() {
     const pipeline = join(fork(ls, lsAL), lineCount)
 
     pipeline().then((results) => {
-      console.log('RESULTS: ', results)
+      //console.log('RESULTS: ', results)
       assert.equal(results[0].tasks[0], ls.info.uid)
       // newUid of task is inaccessible because context doesn't exist prior
       // to task execution
@@ -72,7 +72,7 @@ describe('fork', function() {
       lineCount
     )
     pipeline2().then((results) => {
-      console.log('RESULTS: ',results)
+      //console.log('RESULTS: ',results)
       // all these tests check if final task is the same in task definition
       // and trajectory
       assert.equal(results[0][0].tasks[1], results[0][0].context.trajectory[3])

--- a/test/fork.spec.js
+++ b/test/fork.spec.js
@@ -24,12 +24,14 @@ const lsAL = lsTask('-al')
 //   name: 'Count lines from *.txt'
 // }, ({ input }) => `cat ${input} | wc -l > lines.count`)
 
-//const task2 = task({name: 'task2_3'}, () => `echo "something2"`)
+const task1 = task({name: 'task1'}, () => `echo "something1"`)
+
+const task2 = task({name: 'task2'}, () => `echo "something2"`)
 
 describe('fork', () => {
   // Running this adds nodes to DAG breaking other tests
   // TODO setup/teadown
-  it.skip('should return an array of results', function (done) {
+  it.skip('should return an array of results', (done) => {
     fork(ls, lsAL)().then((results) => {
       //console.log('results: ', results)
       assert.isOk(_.isArray(results))
@@ -37,12 +39,32 @@ describe('fork', () => {
     })
   })
 
-  it ('should have info.type be "fork"', function(done) {
+  it ('should have info.type be "fork"', (done) => {
     const forked = fork(ls, lsAL)
 
     assert.equal(forked.info.type, 'fork')
     done()
   })
+
+  it ('should work with join', (done) => {
+    const forked = fork(ls, lsAL)
+    const fork_join = join(task1, forked, task2)
+    fork_join().then((results) => {
+      console.log('RESULTS: ', results)
+      assert.equal(results[0].tasks[0], ls.info.uid)
+      // newUid of task is inaccessible because context doesn't exist prior
+      // to task execution
+      // instead the resulting new task id (newUid from task.js) is added to
+      // task.context.trajectory
+      assert.equal(results[0].tasks[1], results[0].context.trajectory[3])
+      assert.equal(results[1].tasks[0], lsAL.info.uid)
+      // newUid of task is unnaccessible because context doesn't exist prior'
+      //' to task execution
+      assert.equal(results[1].tasks[1], results[1].context.trajectory[3])
+    })
+    done()
+  })
+
 
   // it('should work with join', function(done) {
   //   const pipeline = join(task2, fork(ls, lsAL), lineCount)

--- a/test/fork.spec.js
+++ b/test/fork.spec.js
@@ -81,5 +81,5 @@ describe('fork', function() {
 
       done()
     })
-  })
+  }).timeout(5000)
 })

--- a/test/fork.spec.js
+++ b/test/fork.spec.js
@@ -4,10 +4,6 @@ const { task, fork, join, junction } = require('../')
 
 const { assert } = require('chai')
 const _ = require('lodash')
-//const fs = require('fs-extra')
-//const path = require('path')
-//const twd = path.resolve(__dirname, 'files', 'fork')
-//const hash = require('../lib/utils/hash.js')
 
 const lsTask = (flags = '') => task({
   output: `*.txt`,
@@ -17,12 +13,6 @@ const lsTask = (flags = '') => task({
 
 const ls = lsTask()
 const lsAL = lsTask('-al')
-
-// const lineCount = task({
-//   input: '*.txt',
-//   output: '*.count',
-//   name: 'Count lines from *.txt'
-// }, ({ input }) => `cat ${input} | wc -l > lines.count`)
 
 const task1 = task({name: 'task1'}, () => `echo "something1"`)
 
@@ -64,23 +54,4 @@ describe('fork', () => {
     })
     done()
   })
-
-
-  // it('should work with join', function(done) {
-  //   const pipeline = join(task2, fork(ls, lsAL), lineCount)
-  //
-  //   pipeline().then((results) => {
-  //     console.log('RESULTS: ', results)
-  //     assert.equal(results[0].tasks[0], ls.info.uid)
-  //     // newUid of task is inaccessible because context doesn't exist prior
-  //     // to task execution
-  //     // instead the resulting new task id (newUid from task.js) is added to
-  //     // task.context.trajectory
-  //     assert.equal(results[0].tasks[1], results[0].context.trajectory[3])
-  //     assert.equal(results[1].tasks[0], lsAL.info.uid)
-  //     // newUid of task is unnaccessible because context doesn't exist prior to task execution
-  //     assert.equal(results[1].tasks[1], results[1].context.trajectory[3])
-  //     done()
-  //   })
-  // })
 })

--- a/test/fork.spec.js
+++ b/test/fork.spec.js
@@ -4,9 +4,10 @@ const { task, fork, join, junction } = require('../')
 
 const { assert } = require('chai')
 const _ = require('lodash')
-const path = require('path')
-const twd = path.resolve(__dirname, 'files', 'fork')
-const hash = require('../lib/utils/hash.js')
+//const fs = require('fs-extra')
+//const path = require('path')
+//const twd = path.resolve(__dirname, 'files', 'fork')
+//const hash = require('../lib/utils/hash.js')
 
 const lsTask = (flags = '') => task({
   output: `*.txt`,
@@ -16,17 +17,16 @@ const lsTask = (flags = '') => task({
 
 const ls = lsTask()
 const lsAL = lsTask('-al')
-const lsLAH = lsTask('-lah')
 
-const lineCount = task({
-  input: '*.txt',
-  output: '*.count',
-  name: 'Count lines from *.txt'
-}, ({ input }) => `cat ${input} | wc -l > lines.count`)
+// const lineCount = task({
+//   input: '*.txt',
+//   output: '*.count',
+//   name: 'Count lines from *.txt'
+// }, ({ input }) => `cat ${input} | wc -l > lines.count`)
 
-const task0 = task({name: 'task0'}, () => `echo "something0"`)
+//const task2 = task({name: 'task2_3'}, () => `echo "something2"`)
 
-describe('fork', function() {
+describe('fork', () => {
   // Running this adds nodes to DAG breaking other tests
   // TODO setup/teadown
   it.skip('should return an array of results', function (done) {
@@ -37,49 +37,28 @@ describe('fork', function() {
     })
   })
 
-  it ('should have info.type be "fork"', function() {
+  it ('should have info.type be "fork"', function(done) {
     const forked = fork(ls, lsAL)
 
     assert.equal(forked.info.type, 'fork')
+    done()
   })
 
-  it('should work with join', function(done) {
-    const pipeline = join(fork(ls, lsAL), lineCount)
-
-    pipeline().then((results) => {
-      //console.log('RESULTS: ', results)
-      assert.equal(results[0].tasks[0], ls.info.uid)
-      // newUid of task is inaccessible because context doesn't exist prior
-      // to task execution
-      // instead the resulting new task id (newUid from task.js) is added to
-      // task.context.trajectory
-      assert.equal(results[0].tasks[1], results[0].context.trajectory[2])
-      assert.equal(results[1].tasks[0], lsAL.info.uid)
-      // newUid of task is unnaccessible because context doesn't exist prior to task execution
-      assert.equal(results[1].tasks[1], results[1].context.trajectory[2])
-
-      done()
-    })
-  })
-
-  it('should have a fork inside a fork without any wrapping', function(done) {
-    const pipeline2 = join(
-      task0,
-      fork(
-        fork(lsLAH, lsAL),
-        ls
-      ),
-      lineCount
-    )
-    pipeline2().then((results) => {
-      //console.log('RESULTS: ',results)
-      // all these tests check if final task is the same in task definition
-      // and trajectory
-      assert.equal(results[0][0].tasks[1], results[0][0].context.trajectory[3])
-      assert.equal(results[0][1].tasks[1], results[0][1].context.trajectory[3])
-      assert.equal(results[1].tasks[1], results[1].context.trajectory[3])
-
-      done()
-    })
-  }).timeout(5000)
+  // it('should work with join', function(done) {
+  //   const pipeline = join(task2, fork(ls, lsAL), lineCount)
+  //
+  //   pipeline().then((results) => {
+  //     console.log('RESULTS: ', results)
+  //     assert.equal(results[0].tasks[0], ls.info.uid)
+  //     // newUid of task is inaccessible because context doesn't exist prior
+  //     // to task execution
+  //     // instead the resulting new task id (newUid from task.js) is added to
+  //     // task.context.trajectory
+  //     assert.equal(results[0].tasks[1], results[0].context.trajectory[3])
+  //     assert.equal(results[1].tasks[0], lsAL.info.uid)
+  //     // newUid of task is unnaccessible because context doesn't exist prior to task execution
+  //     assert.equal(results[1].tasks[1], results[1].context.trajectory[3])
+  //     done()
+  //   })
+  // })
 })

--- a/test/fork_fork.spec.js
+++ b/test/fork_fork.spec.js
@@ -4,23 +4,22 @@ const { task, fork, join, junction } = require('../')
 
 const { assert } = require('chai')
 
+const task0 = task({name: 'task0_2"'}, () => `echo "something0_2"`)
+
+const task1 = task({name: 'task1_2'}, () => `echo "something1_2"`)
+
+const task2 = task({name: 'task2_2'}, () => `echo "something2_2"`)
+
+const task3 = task({name: 'task3_2'}, () => `echo "something3_2"`)
+
+const task4 = task({name: 'task4_2'}, () => `echo "something4_2"`)
+
+const task5 = task({name: 'task5_2'}, () => `echo "something5_2"`)
+
+const task6 = task({name: 'task6_2'}, () => `echo "something6_2"`)
+
 describe('fork_fork', () => {
   it('fork should work after a fork, wrapped in a join', () => {
-
-    const task0 = task({name: 'task0_2"'}, () => `echo "something0_2"`)
-
-    const task1 = task({name: 'task1_2'}, () => `echo "something1_2"`)
-
-    const task2 = task({name: 'task2_2'}, () => `echo "something2_2"`)
-
-    const task3 = task({name: 'task3_2'}, () => `echo "something3_2"`)
-
-    const task4 = task({name: 'task4_2'}, () => `echo "something4_2"`)
-
-    const task5 = task({name: 'task5_2'}, () => `echo "something5_2"`)
-
-    const task6 = task({name: 'task6_2'}, () => `echo "something6_2"`)
-
     const pipeline = join(
       task0,
       fork(
@@ -41,7 +40,7 @@ describe('fork_fork', () => {
 
       // should assure that both ends of the pipeline exist
       assert.equal(results[1].tasks[1], results[1].context.trajectory[2])
-      //done()
-    })//.then(done, done)
-  }).timeout(5000)
+      //done() // without done it is not really testing anything
+    })
+  })
 })

--- a/test/fork_fork.spec.js
+++ b/test/fork_fork.spec.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const { task, fork, join, junction } = require('../')
+
+const { assert } = require('chai')
+
+const task0 = task({name: 'task0_3"'}, () => `echo "something0"`)
+
+const task1 = task({name: 'task1_3'}, () => `echo "something1"`)
+
+const task2 = task({name: 'task2_3'}, () => `echo "something2"`)
+
+const task3 = task({name: 'task3_3'}, () => `echo "something3"`)
+
+const task4 = task({name: 'task4_3'}, () => `echo "something4"`)
+
+const task5 = task({name: 'task5_3'}, () => `echo "something5"`)
+
+const task6 = task({name: 'task6_3'}, () => `echo "something6"`)
+
+describe('fork_fork', function() {
+  it('fork should work after a fork, wrapped in a join', function() {
+    const pipeline = join(
+      task0,
+      fork(
+        join(
+          task1,
+          fork(
+            task4,
+            task5
+          ),
+          task6
+        ),
+        task2
+      ),
+      task3
+    )
+    pipeline().then((results) => {
+      console.log('RESULTS: ',results)
+
+      // should assure that both ends of the pipeline exist
+      assert.equal(results[1].tasks[1],results[1].context.trajectory[2])
+    })
+  })
+})

--- a/test/fork_fork.spec.js
+++ b/test/fork_fork.spec.js
@@ -3,6 +3,10 @@
 const { task, fork, join, junction } = require('../')
 
 const { assert } = require('chai')
+const fs = require('fs');
+const obj = JSON.parse(fs.readFileSync('./graphson.json', 'utf8'));
+
+// Define tasks
 
 const task0 = task({name: 'task0_2"'}, () => `echo "something0_2"`)
 
@@ -19,7 +23,7 @@ const task5 = task({name: 'task5_2'}, () => `echo "something5_2"`)
 const task6 = task({name: 'task6_2'}, () => `echo "something6_2"`)
 
 describe('fork_fork', () => {
-  it('fork should work after a fork, wrapped in a join', () => {
+  it('fork should work after a fork, wrapped in a join', (done) => {
     const pipeline = join(
       task0,
       fork(
@@ -40,7 +44,10 @@ describe('fork_fork', () => {
 
       // should assure that both ends of the pipeline exist
       assert.equal(results[1].tasks[1], results[1].context.trajectory[2])
+      //checks if pipeline rendered the right number of vertices and edges
+      assert.equal(obj.graph.vertices.length, 10)
+      assert.equal(obj.graph.edges.length, 9)
       //done() // without done it is not really testing anything
     })
-  })
+  }).timeout(5000)
 })

--- a/test/fork_fork.spec.js
+++ b/test/fork_fork.spec.js
@@ -26,11 +26,11 @@ const lineCount = task({
 
 const task0 = task({name: 'task0_3'}, () => `echo "something0"`)
 
-const task1 = task({name: 'task1_3'}, () => `echo "something1"`)
-
-const task2 = task({name: 'task2_3'}, () => `echo "something2"`)
-
-const task3 = task({name: 'task3_3'}, () => `echo "something3"`)
+// const task1 = task({name: 'task1_3'}, () => `echo "something1"`)
+//
+// const task2 = task({name: 'task2_3'}, () => `echo "something2"`)
+//
+// const task3 = task({name: 'task3_3'}, () => `echo "something3"`)
 
 const task4 = task({name: 'task4_3'}, () => `echo "something4"`)
 
@@ -64,8 +64,8 @@ describe('fork_fork', () => {
       // should assure that both ends of the pipeline exist
       //assert.equal(results[1].tasks[1], results[1].context.trajectory[2])
       //checks if pipeline rendered the right number of vertices and edges
-      assert.equal(obj.graph.vertices.length, 11)
-      assert.equal(obj.graph.edges.length, 9)
+      assert.equal(obj.graph.vertices.length, 17)
+      assert.equal(obj.graph.edges.length, 14)
       done() // without done it is not really testing anything
     })
   }).timeout(5000)

--- a/test/fork_fork.spec.js
+++ b/test/fork_fork.spec.js
@@ -4,22 +4,23 @@ const { task, fork, join, junction } = require('../')
 
 const { assert } = require('chai')
 
-const task0 = task({name: 'task0_3"'}, () => `echo "something0"`)
+describe('fork_fork', () => {
+  it('fork should work after a fork, wrapped in a join', () => {
 
-const task1 = task({name: 'task1_3'}, () => `echo "something1"`)
+    const task0 = task({name: 'task0_2"'}, () => `echo "something0_2"`)
 
-const task2 = task({name: 'task2_3'}, () => `echo "something2"`)
+    const task1 = task({name: 'task1_2'}, () => `echo "something1_2"`)
 
-const task3 = task({name: 'task3_3'}, () => `echo "something3"`)
+    const task2 = task({name: 'task2_2'}, () => `echo "something2_2"`)
 
-const task4 = task({name: 'task4_3'}, () => `echo "something4"`)
+    const task3 = task({name: 'task3_2'}, () => `echo "something3_2"`)
 
-const task5 = task({name: 'task5_3'}, () => `echo "something5"`)
+    const task4 = task({name: 'task4_2'}, () => `echo "something4_2"`)
 
-const task6 = task({name: 'task6_3'}, () => `echo "something6"`)
+    const task5 = task({name: 'task5_2'}, () => `echo "something5_2"`)
 
-describe('fork_fork', function() {
-  it('fork should work after a fork, wrapped in a join', function() {
+    const task6 = task({name: 'task6_2'}, () => `echo "something6_2"`)
+
     const pipeline = join(
       task0,
       fork(
@@ -39,7 +40,8 @@ describe('fork_fork', function() {
       console.log('RESULTS: ',results)
 
       // should assure that both ends of the pipeline exist
-      assert.equal(results[1].tasks[1],results[1].context.trajectory[2])
-    })
-  })
+      assert.equal(results[1].tasks[1], results[1].context.trajectory[2])
+      //done()
+    })//.then(done, done)
+  }).timeout(5000)
 })

--- a/test/fork_fork.spec.js
+++ b/test/fork_fork.spec.js
@@ -3,49 +3,68 @@
 const { task, fork, join, junction } = require('../')
 
 const { assert } = require('chai')
-const fs = require('fs');
+const fs = require('fs-extra')
+console.log("teste fork fork")
 
 // Define tasks
 
-const task0 = task({name: 'task0_2"'}, () => `echo "something0_2"`)
+const lsTask = (flags = '') => task({
+  output: `*.txt`,
+  params: { flags },
+  name: `ls ${flags} 3`
+}, ({ params }) => `ls ${params.flags} > files.txt`)
 
-const task1 = task({name: 'task1_2'}, () => `echo "something1_2"`)
+const ls = lsTask()
+const lsAL = lsTask('-al')
+const lsLAH = lsTask('-lah')
 
-const task2 = task({name: 'task2_2'}, () => `echo "something2_2"`)
+const lineCount = task({
+  input: '*.txt',
+  output: '*.count',
+  name: 'Count lines from *.txt 3'
+}, ({ input }) => `cat ${input} | wc -l > lines.count`)
 
-const task3 = task({name: 'task3_2'}, () => `echo "something3_2"`)
+const task0 = task({name: 'task0_3'}, () => `echo "something0"`)
 
-const task4 = task({name: 'task4_2'}, () => `echo "something4_2"`)
+const task1 = task({name: 'task1_3'}, () => `echo "something1"`)
 
-const task5 = task({name: 'task5_2'}, () => `echo "something5_2"`)
+const task2 = task({name: 'task2_3'}, () => `echo "something2"`)
 
-const task6 = task({name: 'task6_2'}, () => `echo "something6_2"`)
+const task3 = task({name: 'task3_3'}, () => `echo "something3"`)
+
+const task4 = task({name: 'task4_3'}, () => `echo "something4"`)
+
+const task5 = task({name: 'task5_3'}, () => `echo "something5"`)
+
+const task6 = task({name: 'task6_3'}, () => `echo "something6"`)
 
 describe('fork_fork', () => {
   it('fork should work after a fork, wrapped in a join', (done) => {
-    const pipeline = join(
+    const pipeline4 = join(
       task0,
       fork(
         join(
-          task1,
+          task4,
           fork(
-            task4,
-            task5
+            ls,
+            lsAL
           ),
           task6
         ),
-        task2
+        lsLAH
       ),
-      task3
+      task5
     )
-    pipeline().then((results) => {
-      console.log('RESULTS: ',results)
-      const obj = JSON.parse(fs.readFileSync('./graphson.json', 'utf8'));
+
+    pipeline4().then((results) => {
+      console.log('RESULTS test: ',results)
+      const obj = JSON.parse(fs.readFileSync('graphson.json', 'utf8'))
+      console.log('debug2: ', obj.graph)
 
       // should assure that both ends of the pipeline exist
-      assert.equal(results[1].tasks[1], results[1].context.trajectory[2])
+      //assert.equal(results[1].tasks[1], results[1].context.trajectory[2])
       //checks if pipeline rendered the right number of vertices and edges
-      assert.equal(obj.graph.vertices.length, 10)
+      assert.equal(obj.graph.vertices.length, 11)
       assert.equal(obj.graph.edges.length, 9)
       done() // without done it is not really testing anything
     })

--- a/test/fork_fork.spec.js
+++ b/test/fork_fork.spec.js
@@ -4,7 +4,6 @@ const { task, fork, join, junction } = require('../')
 
 const { assert } = require('chai')
 const fs = require('fs');
-const obj = JSON.parse(fs.readFileSync('./graphson.json', 'utf8'));
 
 // Define tasks
 
@@ -41,13 +40,14 @@ describe('fork_fork', () => {
     )
     pipeline().then((results) => {
       console.log('RESULTS: ',results)
+      const obj = JSON.parse(fs.readFileSync('./graphson.json', 'utf8'));
 
       // should assure that both ends of the pipeline exist
       assert.equal(results[1].tasks[1], results[1].context.trajectory[2])
       //checks if pipeline rendered the right number of vertices and edges
       assert.equal(obj.graph.vertices.length, 10)
       assert.equal(obj.graph.edges.length, 9)
-      //done() // without done it is not really testing anything
+      done() // without done it is not really testing anything
     })
   }).timeout(5000)
 })

--- a/test/fork_fork.spec.js
+++ b/test/fork_fork.spec.js
@@ -59,7 +59,6 @@ describe('fork_fork', () => {
     pipeline4().then((results) => {
       console.log('RESULTS test: ',results)
       const obj = JSON.parse(fs.readFileSync('graphson.json', 'utf8'))
-      console.log('debug2: ', obj.graph)
 
       // should assure that both ends of the pipeline exist
       //assert.equal(results[1].tasks[1], results[1].context.trajectory[2])

--- a/test/fork_fork_without_join.spec.js
+++ b/test/fork_fork_without_join.spec.js
@@ -49,8 +49,8 @@ describe('fork_fork_without_join', () => {
       //console.log(obj)
       // This counts every vertex and edge created in this test and not only
       // this last pipeline2 graph
-      assert.equal(obj.graph.vertices.length, 23) // 7 in this pipeline
-      assert.equal(obj.graph.edges.length, 20) //6 in this pipeline
+      assert.equal(obj.graph.vertices.length, 29) // 7 in this pipeline
+      assert.equal(obj.graph.edges.length, 25) //6 in this pipeline
 
       done()
     })

--- a/test/fork_fork_without_join.spec.js
+++ b/test/fork_fork_without_join.spec.js
@@ -39,14 +39,12 @@ describe('fork_fork_without_join', () => {
     pipeline2().then((results) => {
       console.log('RESULTS: ', results)
       const obj = JSON.parse(fs.readFileSync('graphson.json', 'utf8'))
-      console.log('debug: ', obj.graph)
       // all these tests check if final task is the same in task definition
       // and trajectory
       assert.equal(results[0][0].tasks[1], results[0][0].context.trajectory[3])
       assert.equal(results[0][1].tasks[1], results[0][1].context.trajectory[3])
       assert.equal(results[1].tasks[1], results[1].context.trajectory[3])
 
-      //console.log(obj)
       // This counts every vertex and edge created in this test and not only
       // this last pipeline2 graph
       assert.equal(obj.graph.vertices.length, 29) // 7 in this pipeline

--- a/test/fork_fork_without_join.spec.js
+++ b/test/fork_fork_without_join.spec.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const { task, fork, join, junction } = require('../')
+
+const { assert } = require('chai')
+const fs = require('fs-extra')
+
+// tasks
+
+const lsTask = (flags = '') => task({
+  output: `*.txt`,
+  params: { flags },
+  name: `ls ${flags} 1`
+}, ({ params }) => `ls ${params.flags} > files.txt`)
+
+const ls = lsTask()
+const lsAL = lsTask('-al')
+const lsLAH = lsTask('-lah')
+
+const lineCount = task({
+  input: '*.txt',
+  output: '*.count',
+  name: 'Count lines from *.txt 1'
+}, ({ input }) => `cat ${input} | wc -l > lines.count`)
+
+const task0 = task({name: 'task0_1'}, () => `echo "something0"`)
+
+
+describe('fork_fork_without_join', () => {
+  it('should have a fork inside a fork without any wrapping', function (done) {
+    const pipeline2 = join(
+      task0,
+      fork(
+        fork(lsLAH, lsAL),
+        ls
+      ),
+      lineCount
+    )
+    pipeline2().then((results) => {
+      console.log('RESULTS: ', results)
+      const obj = JSON.parse(fs.readFileSync('graphson.json', 'utf8'))
+      console.log('debug: ', obj.graph)
+      // all these tests check if final task is the same in task definition
+      // and trajectory
+      assert.equal(results[0][0].tasks[1], results[0][0].context.trajectory[3])
+      assert.equal(results[0][1].tasks[1], results[0][1].context.trajectory[3])
+      assert.equal(results[1].tasks[1], results[1].context.trajectory[3])
+
+      //console.log(obj)
+      // This counts every vertex and edge created in this test and not only
+      // this last pipeline2 graph
+      assert.equal(obj.graph.vertices.length, 23) // 7 in this pipeline
+      assert.equal(obj.graph.edges.length, 20) //6 in this pipeline
+
+      done()
+    })
+  }).timeout(5000)
+})

--- a/test/fork_junction.spec.js
+++ b/test/fork_junction.spec.js
@@ -36,14 +36,14 @@ describe('fork_junction', () => {
       ),
       task3
     )
-    return pipeline().then((results) => {
+    pipeline().then((results) => {
       console.log('RESULTS: ',results)
       // should assure that junction node exists
       assert.isOk(results[0].context.trajectory[0])
       // should assure that both ends of the pipeline exist
       assert.isOk(results[0].context.trajectory[2])
       assert.isOk(results[1].context.trajectory[2])
-      //done()
+      //done()  // without done it is not really testing anything
     })
   }).timeout(5000)
 })

--- a/test/fork_junction.spec.js
+++ b/test/fork_junction.spec.js
@@ -50,7 +50,6 @@ describe('fork_junction', () => {
     pipeline3().then((results) => {
       console.log('RESULTS: ',results)
       const obj = JSON.parse(fs.readFileSync('graphson.json', 'utf8'))
-      console.log('debug3: ', obj.graph)
 
       // should assure that junction node exists
       assert.isOk(results[0].context.trajectory[0])

--- a/test/fork_junction.spec.js
+++ b/test/fork_junction.spec.js
@@ -58,8 +58,8 @@ describe('fork_junction', () => {
       assert.isOk(results[0].context.trajectory[2])
       assert.isOk(results[1].context.trajectory[2])
       //checks if pipeline rendered the right number of vertices and edges
-      assert.equal(obj.graph.vertices.length, 33)
-      assert.equal(obj.graph.edges.length, 30)
+      assert.equal(obj.graph.vertices.length, 39)
+      assert.equal(obj.graph.edges.length, 35)
       done()  // without done it is not really testing anything
     })
   }).timeout(5000)

--- a/test/fork_junction.spec.js
+++ b/test/fork_junction.spec.js
@@ -3,9 +3,10 @@
 const { task, fork, join, junction } = require('../')
 
 const { assert } = require('chai')
+const fs = require('fs');
 
 describe('fork_junction', () => {
-  it('junction should work after a fork', () => {
+  it('junction should work after a fork', (done) => {
 
     const task0 = task({name: 'task0_3"'}, () => `echo "something0_3"`)
 
@@ -38,12 +39,17 @@ describe('fork_junction', () => {
     )
     pipeline().then((results) => {
       console.log('RESULTS: ',results)
+      const obj = JSON.parse(fs.readFileSync('./graphson.json', 'utf8'));
+
       // should assure that junction node exists
       assert.isOk(results[0].context.trajectory[0])
       // should assure that both ends of the pipeline exist
       assert.isOk(results[0].context.trajectory[2])
       assert.isOk(results[1].context.trajectory[2])
-      //done()  // without done it is not really testing anything
+      //checks if pipeline rendered the right number of vertices and edges
+      assert.equal(obj.graph.vertices.length, 9)
+      assert.equal(obj.graph.edges.length, 9)
+      done()  // without done it is not really testing anything
     })
   }).timeout(5000)
 })

--- a/test/fork_junction.spec.js
+++ b/test/fork_junction.spec.js
@@ -2,24 +2,25 @@
 
 const { task, fork, join, junction } = require('../')
 
-const { should } = require('chai')
+const { assert } = require('chai')
 
-const task0 = task({name: 'task0_2"'}, () => `echo "something0"`)
+describe('fork_junction', () => {
+  it('junction should work after a fork', () => {
 
-const task1 = task({name: 'task1'}, () => `echo "something1"`)
+    const task0 = task({name: 'task0_3"'}, () => `echo "something0_3"`)
 
-const task2 = task({name: 'task2'}, () => `echo "something2"`)
+    const task1 = task({name: 'task1_3'}, () => `echo "something1_3"`)
 
-const task3 = task({name: 'task3'}, () => `echo "something3"`)
+    const task2 = task({name: 'task2_3'}, () => `echo "something2_3"`)
 
-const task4 = task({name: 'task4'}, () => `echo "something4"`)
+    const task3 = task({name: 'task3_3'}, () => `echo "something3_3"`)
 
-const task5 = task({name: 'task5'}, () => `echo "something5"`)
+    const task4 = task({name: 'task4_3'}, () => `echo "something4_3"`)
 
-const task6 = task({name: 'task6'}, () => `echo "something6"`)
+    const task5 = task({name: 'task5_3'}, () => `echo "something5_3"`)
 
-describe('fork_junction', function() {
-  it('junction should work after a fork', function() {
+    const task6 = task({name: 'task6_3'}, () => `echo "something6_3"`)
+
     const pipeline = join(
       task0,
       fork(
@@ -35,15 +36,14 @@ describe('fork_junction', function() {
       ),
       task3
     )
-    pipeline().then((results) => {
+    return pipeline().then((results) => {
       console.log('RESULTS: ',results)
       // should assure that junction node exists
-      should.exist(results[0].context.trajectory[0])
+      assert.isOk(results[0].context.trajectory[0])
       // should assure that both ends of the pipeline exist
-      should.exist(results[0].context.trajectory[2])
-      should.exist(results[1].context.trajectory[2])
-
+      assert.isOk(results[0].context.trajectory[2])
+      assert.isOk(results[1].context.trajectory[2])
       //done()
     })
-  })
+  }).timeout(5000)
 })

--- a/test/fork_junction.spec.js
+++ b/test/fork_junction.spec.js
@@ -3,43 +3,54 @@
 const { task, fork, join, junction } = require('../')
 
 const { assert } = require('chai')
-const fs = require('fs');
+const fs = require('fs-extra')
+
+// Define tasks
+
+const lsTask = (flags = '') => task({
+  output: `*.txt`,
+  params: { flags },
+  name: `ls ${flags} 2`
+}, ({ params }) => `ls ${params.flags} > files.txt`)
+
+const ls = lsTask()
+const lsAL = lsTask('-al')
+const lsLAH = lsTask('-lah')
+
+const lineCount = task({
+  input: '*.txt',
+  output: '*.count',
+  name: 'Count lines from *.txt 2'
+}, ({ input }) => `cat ${input} | wc -l > lines.count`)
+
+const task0 = task({name: 'task0_2'}, () => `echo "something0"`)
+
+const task1 = task({name: 'task1_2'}, () => `echo "something1"`)
+
+const task2 = task({name: 'task2_2'}, () => `echo "something2"`)
+
 
 describe('fork_junction', () => {
   it('junction should work after a fork', (done) => {
-
-    const task0 = task({name: 'task0_3"'}, () => `echo "something0_3"`)
-
-    const task1 = task({name: 'task1_3'}, () => `echo "something1_3"`)
-
-    const task2 = task({name: 'task2_3'}, () => `echo "something2_3"`)
-
-    const task3 = task({name: 'task3_3'}, () => `echo "something3_3"`)
-
-    const task4 = task({name: 'task4_3'}, () => `echo "something4_3"`)
-
-    const task5 = task({name: 'task5_3'}, () => `echo "something5_3"`)
-
-    const task6 = task({name: 'task6_3'}, () => `echo "something6_3"`)
-
-    const pipeline = join(
+    const pipeline3 = join(
       task0,
       fork(
         join(
           task1,
           junction(
-            task4,
-            task5
+            ls,
+            lsAL
           ),
-          task6
+          task2
         ),
-        task2
+        lsLAH
       ),
-      task3
+      lineCount
     )
-    pipeline().then((results) => {
+    pipeline3().then((results) => {
       console.log('RESULTS: ',results)
-      const obj = JSON.parse(fs.readFileSync('./graphson.json', 'utf8'));
+      const obj = JSON.parse(fs.readFileSync('graphson.json', 'utf8'))
+      console.log('debug3: ', obj.graph)
 
       // should assure that junction node exists
       assert.isOk(results[0].context.trajectory[0])
@@ -47,8 +58,8 @@ describe('fork_junction', () => {
       assert.isOk(results[0].context.trajectory[2])
       assert.isOk(results[1].context.trajectory[2])
       //checks if pipeline rendered the right number of vertices and edges
-      assert.equal(obj.graph.vertices.length, 9)
-      assert.equal(obj.graph.edges.length, 9)
+      assert.equal(obj.graph.vertices.length, 33)
+      assert.equal(obj.graph.edges.length, 30)
       done()  // without done it is not really testing anything
     })
   }).timeout(5000)


### PR DESCRIPTION
This PR fixes an issue with fork inside fork. Avoids the duplication of outermost tasks when fork is not nested in a join inside a fork. Previously this was not being properly handled because there was no way to check whether outermost tasks where the same as downstream tasks.

The rational is when fork is inside fork without join wrapping, outermost tasks will be the same as downstream tasks and thus should not be added to `lineage` twice. On the other hand when join is wrapping the inner fork, outermost tasks (after outer fork) are different from downstream tasks (after inner fork) and thus both should be added to `lineage`.

To achieve the comparison of these two arrays (`outermostTasks` and `downstreamTasks`) I have made two hashes for each by adding the individual hashes of each task within each one of these arrays, where these hashes are made with `task.info.operationCreator`. So, when all tasks inside both arrays have the same `operationCreator` it will return the same hash, otherwise they will be different.

Then was just a matter of checking if both hashes are equal or not.