### PR TITLE
Change on the behavior of d3 visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Global installation:
 
 ## Documentation
 
-Our documentation is available [here](https://thejmazz.gitbooks.io/bionode-watermill/content/). 
+Our documentation is available [here](https://bionode.gitbooks.io/bionode-watermill/content/). 
 There you may find how to **use** bionode-watermill to construct and **run** 
 your 
 pipelines. Moreover, you will also find the description of the API to help 

--- a/docs/D3Visualization.md
+++ b/docs/D3Visualization.md
@@ -7,11 +7,16 @@ the scripts in `localhost:8084`. Visualization script is available in
 
 ## Enabling visualization
 
-Just paste `localhost:8084` on your browser URL.
+Pass the following environmental variable before running the desired 
+pipeline: `D3_LOGGER=1`. Then, just paste `localhost:8084` on 
+your browser URL.
+
+> For more information on the usage of environmental variables, please refer 
+to this [section](Loggers.md).
 
 ## Canceling
 
-Now, this tool hangs each script at its end and in order to exit it, just 
+This tool hangs each script at its end and in order to exit it, just 
 hit: `ctrl + c` in the shell terminal where the pipeline script is running. 
 Hitting `ctrl + c` will close the connection between the browser and 
 `lib/reducers/collections.js`.

--- a/docs/Loggers.md
+++ b/docs/Loggers.md
@@ -1,0 +1,49 @@
+# Loggers
+
+Currently bionode-watermill has three main logging options.
+
+## Chrome inspector
+
+You can run any standard bionode-watermill script using google chrome 
+inspector, like this:
+
+```
+node --inspect pipeline.js
+```
+
+This will log both to the console and to google chrome. It will give you a 
+link where you can see the logs. There are also some google chrome plugins 
+that allow for the debugger to open automatically.
+
+## Redux logger
+
+Since bionode-watermill uses `redux` to manage `actions` and `states` and not
+ allways what is going on within redux is clear, `redux-logger` greatly helps
+  seeing what is happening on each task. You have `previous state`, `action` 
+  and `next action` which as it says is useful to access what happens on each
+   `reducer` and this might be useful for debugging your pipeline.
+   
+   This logger is available in bionode-watermill through an environmental 
+   variable `REDUX_LOGGER=1`.
+   
+   ```
+REDUX_LOGGER=1 node --inspect pipeline.js
+``` 
+
+Here it is strongly recommended to use chrome inspector since `redux-logger` 
+prints a lot of outputs and they can be interact with.
+
+## D3 logger or D3 visualization
+
+D3 logger is basically a visualization tool that allows the user to check the
+ pipeline shape, outputs/inputs and commands being executed using `d3`. This 
+ can be accessed by passing another environmental variable `D3_LOGGER=1`.
+ 
+ ```
+D3_LOGGER=1 node pipeline.js
+```
+
+This will send `graphson` object to `d3` in order to draw the aspect of the 
+pipeline and can be accessed in `http://localhost:8084/`. Other metadata of 
+each task will be also shown on hovering (for more details see 
+[D3Visualization](D3Visualization.md)).

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -66,3 +66,14 @@ In the above represented `pipeline`, first bionode-watermill will fetch input
     is wrapping everything else! It is in fact making sure everything is run 
     in the order you desire. **Commas are like pauses in join**, it makes 
     sure the pipeline waits for the task before to be finished.
+
+## Running a pipeline
+
+After having making your own script named `pipeline.js` (or whatever you want
+ the name to be), just run the following command on your Unix terminal.
+
+```shell
+node pipeline.js
+```
+
+> There some other logging options that you can explore [here](Loggers.md).

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -76,4 +76,4 @@ After having making your own script named `pipeline.js` (or whatever you want
 node pipeline.js
 ```
 
-> There some other logging options that you can explore [here](Loggers.md).
+> There are some other logging options that you can explore [here](Loggers.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 * Example Pipelines
     * [two-mappers](../examples/pipelines/two-mappers/README.md) - a pipeline
      that uses two mappers for benchmark purposes.
+* [Loggers](Loggers.md)
 * API
     * [Task](Task.md)
         - [Lifecycle](TaskLifecycle.md)

--- a/lib/reducers/collection.js
+++ b/lib/reducers/collection.js
@@ -9,40 +9,26 @@ const http = require('http')
 const fs = require('fs')
 const path = require('path')
 
-// define path to index.html, otherwise it will be relative to dir where
-// scripts is run
-const scr = path.join(__dirname, '../../viz/index.html')
-
-// Loading the index file . html displayed to the client
-
-const server = http.createServer(function(req, res) {
-  fs.readFile(scr, 'utf-8', function(err, content) {
-    res.writeHead(200, {"Content-Type": "text/html"})
-    res.end(content)
-  })
-})
-
-// Loading socket.io
-
-const io = require('socket.io').listen(server)
-
-// sets MaxListeners without limit, important if several instances of
-// socket.io are expected (e.g. if we have several junctions, forks, and
-// even tasks)
-io.sockets.setMaxListeners(0)
-
-// When a client connects, we note it in the console
-io.sockets.on('connection', function (socket) {
-  console.log('A client is connected!')
-})
-server.listen(8084)
-
 // Actions
 const ADD_OUTPUT = 'collection/add-output'
 const ADD_JUNCTION_VERTEX = 'collection/add-junction-vertex'
 
 const defaultState = new Graph()
 
+// define path to index.html, otherwise it will be relative to dir where
+// scripts is run
+const scr = path.join(__dirname, '../../viz/index.html')
+
+// Loading the index file . html displayed to the client
+const server = http.createServer( (req, res) => {
+  fs.readFile(scr, 'utf-8', (err, content)  => {
+    res.writeHead(200, {"Content-Type": "text/html"})
+    res.end(content)
+  })
+})
+
+// Loading socket.io
+const io = require('socket.io').listen(server)
 
 const reducer = (state = defaultState, action) => {
   switch (action.type) {
@@ -110,20 +96,41 @@ const jsonifyGraph = (graph, obj = {}) => {
   // writes each graphson to file
   fs.writeFile('graphson.json', JSON.stringify(graphsonObj, null, 2), (err) => {
     if (err) throw err
-    console.log('File was saved!')
+    // TODO make this log just once
+    console.log('File was saved as graphson.json!')
   })
 
-  // Output to visualization server
-  io.sockets.on('connection', function (socket) {
-    socket.emit('message', graphsonObj)
-  })
+  // checks if environmental variable is set to 1 or not to use d3
+  // visualization tool
+  const d3Env = process.env.D3_LOGGER
+
+  if (d3Env === '1') {
+    // sets MaxListeners without limit, important if several instances of
+    // socket.io are expected (e.g. if we have several junctions, forks, and
+    // even tasks)
+    io.sockets.setMaxListeners(0)
+
+    // When a client connects, we note it in the console
+    //io.sockets.on('connection', function (socket) {
+    //  console.log('A client is connected!')
+    //})
+    server.listen(8084)
+
+    // Output to visualization server
+    io.sockets.on('connection', (socket) => {
+      // TODO make this log just once
+      console.log('d3 visualization on! check it on http://localhost:8084/.' +
+        ' To disconnect please do ctrl + c.')
+      socket.emit('message', graphsonObj)
+    })
+  }
 
   Object.keys(obj).forEach(key => Object.assign(obj[key], travelNode(key)))
 
   return obj
 }
 
-function addOutputHandler (state, action) {
+const addOutputHandler = (state, action) => {
   // TODO remove duplicate code b/w this, and creating the next trajection in join
   const {
     type,
@@ -177,7 +184,7 @@ function addOutputHandler (state, action) {
   return graph
 }
 
-function addJunctionVertexHandler(state, action) {
+const addJunctionVertexHandler = (state, action) => {
   const { uid, results } = action
 
   // Clone graph to maintain immutable state


### PR DESCRIPTION
I have passed an environmental variable for d3 visualization tool to be triggered. Now it is only started when we pass the `D3_LOGGER` environmental variable to the shell before running the script. Also, I added these changes to the docs.